### PR TITLE
Support spaces in the cloned path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ASMFILES := $(foreach dir,$(SOURCE_ALL_DIRS),$(wildcard $(dir)/*.asm))
 
 # List of include directories: All source and data folders.
 # A '/' is appended to the path.
-INCLUDES := $(foreach dir,$(SOURCE_ALL_DIRS),-i$(CURDIR)/$(dir)/)
+INCLUDES := $(foreach dir,$(SOURCE_ALL_DIRS),-i$(dir)/)
 
 # Prepare object paths from source files.
 OBJ := $(ASMFILES:.asm=.obj)


### PR DESCRIPTION
Apologies for intruding on your personal project, but here's a little tweak to the Makefile that I spotted when doing things with the tests in rgbds. Hope that's OK!

---

Before, the path to the current directory (i.e. the path to which µcity was cloned) would be included as part of each INCLUDE flag. However, this didn’t work if the path to the current directory includes spaces (e.g. within a folder called `Game Boy`).

To fix this, I’m simply passing `-i$(dir)/` (without the current directory prefix), as it can be found within the current directory without needing to manually add the prefix.

If there was a reason for that prefix in the first place, I'm happy to be corrected!