### PR TITLE
Use `sort` after `wildcard` for predictable file order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ BIN := $(NAME).$(EXT)
 COMPAT_BIN := $(NAME)_compat.$(EXT)
 
 # List of relative paths to all folders and subfolders with code or data.
-SOURCE_ALL_DIRS := $(shell find $(SOURCE) -type d -print)
+SOURCE_ALL_DIRS := $(sort $(shell find $(SOURCE) -type d -print))
 
 # All files with extension asm are assembled.
-ASMFILES := $(foreach dir,$(SOURCE_ALL_DIRS),$(wildcard $(dir)/*.asm))
+ASMFILES := $(foreach dir,$(SOURCE_ALL_DIRS),$(sort $(wildcard $(dir)/*.asm)))
 
 # List of include directories: All source and data folders.
 # A '/' is appended to the path.


### PR DESCRIPTION
Fixes #7

I'll update RGBDS CI to use this commit after it's merged.