### PR TITLE
Use `ldh [$ff00+c]`, not `ld [$ff00+c]`, and fix a `rRAMG` bug

### DIFF
--- a/source/bg_handler.asm
+++ b/source/bg_handler.asm
@@ -117,7 +117,7 @@ ____vram_copy_row_wrap:: ; b = x, c = y, hl = source address
         di ; Entering critical section
 
 .wait\@: ; wait until mode 0 or 1
-        ld      a,[$FF00+c]
+        ldh     a,[$FF00+c]
         bit     1,a
         jr      nz,.wait\@
 
@@ -216,7 +216,7 @@ ____vram_copy_column_wrap:: ; b = x, c = y, hl = source address
         di ; Entering critical section
 
 .wait\@: ; wait until mode 0 or 1
-        ld      a,[$FF00+c]
+        ldh     a,[$FF00+c]
         bit     1,a
         jr      nz,.wait\@
 

--- a/source/engine/engine.inc
+++ b/source/engine/engine.inc
@@ -69,7 +69,7 @@ ENDM
 MACRO WAIT_SCREEN_BLANK ; Clobbers registers A and C
     ld      c,rSTAT & $FF
 .loop\@:
-    ld      a,[$FF00+c]
+    ldh     a,[$FF00+c]
     bit     1,a
     jr      nz,.loop\@ ; Not mode 0 or 1
 ENDM

--- a/source/engine/gbt_player_bank1.asm
+++ b/source/engine/gbt_player_bank1.asm
@@ -930,7 +930,7 @@ gbt_channel3_load_instrument:
     ld      b,16
 .loop:
     ld      a,[hl+]
-    ld      [$FF00+c],a
+    ldh     [$FF00+c],a
     inc     c
     dec     b
     jr      nz,.loop

--- a/source/engine/video.asm
+++ b/source/engine/video.asm
@@ -40,7 +40,7 @@ wait_ly::
     ld      c,rLY & $FF
 
 .loop:
-    ld      a,[$FF00+c]
+    ldh     a,[$FF00+c]
     cp      a,b
     ret     z
     jr      .loop
@@ -105,7 +105,7 @@ vram_copy_fast::
     ld      c,rSTAT & $FF
 
 .loop:
-    ld      a,[$FF00+c]
+    ldh     a,[$FF00+c]
     bit     1,a
     jr      nz,.loop ; Not mode 0 or 1
 

--- a/source/main.asm
+++ b/source/main.asm
@@ -265,8 +265,8 @@ SetPalettesAllBlack::
     ld      [hl],a
     ld      [hl],a
 
-    ld      [$FF00+c],a
-    ld      [$FF00+c],a
+    ldh     [$FF00+c],a
+    ldh     [$FF00+c],a
     ENDR
     dec     b
     jr      nz,.loop

--- a/source/room_save_menu/room_save_menu.asm
+++ b/source/room_save_menu/room_save_menu.asm
@@ -217,7 +217,7 @@ SaveMenuPrintSRAMBankInfo:
     inc     de
 
     ld      a,CART_RAM_DISABLE
-    ldh     [rRAMG],a
+    ld      [rRAMG],a
 
     pop     bc
 


### PR DESCRIPTION
RGBDS 0.9.0 [deprecates](https://rgbds.gbdev.io/docs/master/rgbasm-old.5#LD__C_,_A_and_LD_A,__C_) `ld [$ff00+c]`.

Note that this also fixes a bug! One line had `ldh [rRAMG], a` instead of `ld [rRAMG], a`. Since `rRAMG` is `$0000`, this was quietly getting assembled as `ldh [$FF00], a` (aka `ldh [rP1], a`) instead of the desired `ld [$0000], a`. (I think this validates our decision to deprecate `ldh [$xx]`!)