### PR TITLE
Avoid warnings from latest RGBDS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,17 +74,17 @@ clean:
 
 %.obj : %.asm
 	@echo rgbasm $<
-	@$(RGBASM) $(INCLUDES) -E -Wall -o$@ $<
+	@$(RGBASM) $(INCLUDES) -E -Weverything -Wno-export-undefined -o$@ $<
 
 $(BIN): $(OBJ)
 	@echo rgblink $(BIN)
 	@$(RGBLINK) -o $(BIN) -p 0xFF -m $(NAME).map -n $(NAME).sym $(OBJ)
 	@echo rgbfix $(BIN)
-	@$(RGBFIX) -p 0xFF -v $(BIN)
+	@$(RGBFIX) -p 0xFF -v -Weverything $(BIN)
 
 $(COMPAT_BIN): $(BIN)
 	@echo rgbfix $(COMPAT_BIN)
 	@cp $(BIN) $(COMPAT_BIN)
-	@$(RGBFIX) -v -Wno-overwrite -r 3 $(COMPAT_BIN)
+	@$(RGBFIX) -v -Weverything -Wno-overwrite -r 3 $(COMPAT_BIN)
 
 ################################################################################


### PR DESCRIPTION
RGBASM 1.0.0 will add an `export-undefined` warning when you `EXPORT` a constant that is not defined yet. It's enabled by default because we expect it to be a mistake most of the time. However, µCity intentionally exports a lot of constants in source/engine/engine.inc before they're defined elsewhere. This PR disables the warning with `-Wno-export-undefined` (and takes the opportunity to enable all other warnings, since µCity passes all of them anyway). This does mean that µCity will require RGBDS 1.0.0 to build, since previous versions won't recognize the `-Wno-export-undefined` flag, so this PR should wait until 1.0.0 is actually released.